### PR TITLE
Updated to latest rustc (switched statics to const)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -28,40 +28,40 @@ use types::{PaError, PaDeviceIndex, PaHostApiIndex, PaStreamCallbackFlags,
 
 // Sample format
 pub type PaSampleFormat = u64;
-pub const PaFloat32: PaSampleFormat = 0x00000001;
-pub const PaInt32: PaSampleFormat = 0x00000002;
-// pub const PaInt24: PaSampleFormat = 0x00000004;
-pub const PaInt16: PaSampleFormat = 0x00000008;
-pub const PaInt8: PaSampleFormat = 0x00000010;
-pub const PaUInt8: PaSampleFormat = 0x00000020;
-pub const PaCustomFormat: PaSampleFormat = 0x00010000;
-pub const PaNonInterleaved: PaSampleFormat = 0x80000000;
+pub const PA_FLOAT_32: PaSampleFormat = 0x00000001;
+pub const PA_INT_32: PaSampleFormat = 0x00000002;
+// pub const PA_INT_24: PaSampleFormat = 0x00000004;
+pub const PA_INT_16: PaSampleFormat = 0x00000008;
+pub const PA_INT_8: PaSampleFormat = 0x00000010;
+pub const PA_UINT_8: PaSampleFormat = 0x00000020;
+pub const PA_CUSTOM_FORMAT: PaSampleFormat = 0x00010000;
+pub const PA_NON_INTERLEAVED: PaSampleFormat = 0x80000000;
 
 // Stream flags
 pub type PaStreamFlags = u64;
-pub const PaNoFlag: PaStreamFlags = 0;
-pub const PaClipOff: PaStreamFlags = 0x00000001;
-pub const PaDitherOff: PaStreamFlags = 0x00000002;
-pub const PaNeverDropInput: PaStreamFlags = 0x00000004;
-pub const PaPrimeOutputBuffersUsingStreamCallback: PaStreamFlags = 0x00000008;
-pub const PaPlatformSpecificFlags: PaStreamFlags = 0xFFFF0000;
+pub const PA_NO_FLAG: PaStreamFlags = 0;
+pub const PA_CLIP_OFF: PaStreamFlags = 0x00000001;
+pub const PA_DITHER_OFF: PaStreamFlags = 0x00000002;
+pub const PA_NEVER_DROP_INPUT: PaStreamFlags = 0x00000004;
+pub const PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK: PaStreamFlags = 0x00000008;
+pub const PA_PLATFORM_SPECIFIC_FLAGS: PaStreamFlags = 0xFFFF0000;
 
 /// Unchanging unique identifiers for each supported host API
 pub type PaHostApiTypeId = i32;
-pub const PaInDevelopment: PaHostApiTypeId = 0;
-pub const PaDirectSound: PaHostApiTypeId = 1;
-pub const PaMME: PaHostApiTypeId = 2;
-pub const PaASIO: PaHostApiTypeId = 3;
-pub const PaSoundManager: PaHostApiTypeId = 4;
-pub const PaCoreAudio: PaHostApiTypeId = 5;
-pub const PaOSS: PaHostApiTypeId = 7;
-pub const PaALSA: PaHostApiTypeId = 8;
-pub const PaAL: PaHostApiTypeId = 9;
-pub const PaBeOS: PaHostApiTypeId = 10;
-pub const PaWDMKS: PaHostApiTypeId = 11;
-pub const PaJACK: PaHostApiTypeId = 12;
-pub const PaWASAPI: PaHostApiTypeId = 13;
-pub const PaAudioScienceHPI: PaHostApiTypeId = 14;
+pub const PA_IN_DEVELOPMENT: PaHostApiTypeId = 0;
+pub const PA_DIRECT_SOUND: PaHostApiTypeId = 1;
+pub const PA_MME: PaHostApiTypeId = 2;
+pub const PA_ASIO: PaHostApiTypeId = 3;
+pub const PA_SOUND_MANAGER: PaHostApiTypeId = 4;
+pub const PA_CORE_AUDIO: PaHostApiTypeId = 5;
+pub const PA_OSS: PaHostApiTypeId = 7;
+pub const PA_ALSA: PaHostApiTypeId = 8;
+pub const PA_AL: PaHostApiTypeId = 9;
+pub const PA_BE_OS: PaHostApiTypeId = 10;
+pub const PA_WDMKS: PaHostApiTypeId = 11;
+pub const PA_JACK: PaHostApiTypeId = 12;
+pub const PA_WASAPI: PaHostApiTypeId = 13;
+pub const PA_AUDIO_SCIENCE_HPI: PaHostApiTypeId = 14;
 
 pub type C_PaStream = c_void;
 

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -645,8 +645,7 @@ impl<S> PaStream<S> {
      * Return Ok(~[S]), a buffer containing the sample of the format S.
      * If fail return a PaError code.
      */
-    #[cfg(target_os="win32")]
-    #[cfg(target_os="linux")]
+    #[cfg(any(target_os="win32", target_os="linux"))]
     pub fn read(&self, frames_per_buffer: u32) -> Result<Vec<S>, PaError> {
         let err = unsafe {
             ffi::Pa_ReadStream(self.c_pa_stream, self.unsafe_buffer, frames_per_buffer)

--- a/src/portaudio.rs
+++ b/src/portaudio.rs
@@ -62,13 +62,10 @@ __rust-portaudio__ is build with the rustpkg tool :
 #![feature(globs)]
 #![warn(missing_doc)]
 #![allow(dead_code)]
-#![allow(visible_private_types)]
 
 extern crate libc;
 
-#[cfg(target_os="macos")]
-#[cfg(target_os="linux")]
-#[cfg(target_os="win32")]
+#[cfg(any(target_os="macos", target_os="linux", target_os="win32"))]
 mod c_library {
     #[link(name = "portaudio")]
     extern {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,10 +33,10 @@ use ffi;
 pub type PaDeviceIndex = i32;
 /// A special PaDeviceIndex value indicating that no device is available,
 /// or should be used.
-pub static PaNoDevice: PaDeviceIndex = -1;
+pub const PA_NO_DEVICE: PaDeviceIndex = -1;
 /// A special PaDeviceIndex value indicating that the device(s) to be used are
 /// specified in the host api specific stream info structure.
-pub static PaUseHostApiSpecificDeviceSpecification: PaDeviceIndex = -2;
+pub const PA_USE_HOST_API_SPECIFIC_DEVICE_SPECIFICATION: PaDeviceIndex = -2;
 
 /// The type used to enumerate to host APIs at runtime.
 /// Values of this type range from 0 to (pa::get_host_api_count()-1).
@@ -50,19 +50,19 @@ pub type PaTime = f64;
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
 pub enum PaSampleFormat {
     /// 32 bits float sample format
-    PaFloat32 =         ffi::PaFloat32,
+    PaFloat32 =         ffi::PA_FLOAT_32,
     /// 32 bits int sample format
-    PaInt32 =           ffi::PaInt32,
+    PaInt32 =           ffi::PA_INT_32,
     /// 16 bits int sample format
-    PaInt16 =           ffi::PaInt16,
+    PaInt16 =           ffi::PA_INT_16,
     /// 8 bits int sample format
-    PaInt8 =            ffi::PaInt8,
+    PaInt8 =            ffi::PA_INT_8,
     /// 8 bits unsigned int sample format
-    PaUInt8 =           ffi::PaUInt8,
+    PaUInt8 =           ffi::PA_UINT_8,
     /// Custom sample format
-    PaCustomFormat =    ffi::PaCustomFormat,
+    PaCustomFormat =    ffi::PA_CUSTOM_FORMAT,
     /// Non interleaved sample format
-    PaNonInterleaved =  ffi::PaNonInterleaved
+    PaNonInterleaved =  ffi::PA_NON_INTERLEAVED
 }
 
 /// The flags to pass to a stream
@@ -70,17 +70,17 @@ pub enum PaSampleFormat {
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
 pub enum PaStreamFlags {
     /// No flags
-    PaNoFlag =                                  ffi::PaNoFlag,
+    PaNoFlag =                                  ffi::PA_NO_FLAG,
     /// Disable default clipping of out of range samples.
-    PaClipOff =                                 ffi::PaClipOff,
+    PaClipOff =                                 ffi::PA_CLIP_OFF,
     /// Disable default dithering.
-    PaDitherOff =                               ffi::PaDitherOff,
+    PaDitherOff =                               ffi::PA_DITHER_OFF,
     /// Flag requests that where possible a full duplex stream will not discard overflowed input samples without calling the stream callback.
-    PaNeverDropInput =                          ffi::PaNeverDropInput,
+    PaNeverDropInput =                          ffi::PA_NEVER_DROP_INPUT,
     /// Call the stream callback to fill initial output buffers, rather than the default behavior of priming the buffers with zeros (silence)
-    PaPrimeOutputBuffersUsingStreamCallback =   ffi::PaPrimeOutputBuffersUsingStreamCallback,
+    PaPrimeOutputBuffersUsingStreamCallback =   ffi::PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK,
     /// A mask specifying the platform specific bits.
-    PaPlatformSpecificFlags =                   ffi::PaPlatformSpecificFlags
+    PaPlatformSpecificFlags =                   ffi::PA_PLATFORM_SPECIFIC_FLAGS
 }
 
 
@@ -175,33 +175,33 @@ pub enum PaError {
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
 pub enum PaHostApiTypeId {
     /// In development host
-    PaInDevelopment =   ffi::PaInDevelopment,
+    PaInDevelopment =   ffi::PA_IN_DEVELOPMENT,
     /// Direct sound
-    PaDirectSound =     ffi::PaDirectSound,
+    PaDirectSound =     ffi::PA_DIRECT_SOUND,
     /// MMe API
-    PaMME =             ffi::PaMME,
+    PaMME =             ffi::PA_MME,
     /// ASIO API
-    PaASIO =            ffi::PaASIO,
+    PaASIO =            ffi::PA_ASIO,
     /// Sound manager API
-    PaSoundManager =    ffi::PaSoundManager,
+    PaSoundManager =    ffi::PA_SOUND_MANAGER,
     /// Core Audio API
-    PaCoreAudio =       ffi::PaCoreAudio,
+    PaCoreAudio =       ffi::PA_CORE_AUDIO,
     /// OSS API
-    PaOSS =             ffi::PaOSS,
+    PaOSS =             ffi::PA_OSS,
     /// Alsa API
-    PaALSA =            ffi::PaALSA,
+    PaALSA =            ffi::PA_ALSA,
     /// AL API
-    PaAL =              ffi::PaAL,
+    PaAL =              ffi::PA_AL,
     /// BeOS API
-    PaBeOS =            ffi::PaBeOS,
+    PaBeOS =            ffi::PA_BE_OS,
     /// WDMKS
-    PaWDMKS =           ffi::PaWDMKS,
+    PaWDMKS =           ffi::PA_WDMKS,
     /// Jack API
-    PaJACK =            ffi::PaJACK,
+    PaJACK =            ffi::PA_JACK,
     /// WASAPI
-    PaWASAPI =          ffi::PaWASAPI,
+    PaWASAPI =          ffi::PA_WASAPI,
     /// Audio Science HPI
-    PaAudioScienceHPI = ffi::PaAudioScienceHPI
+    PaAudioScienceHPI = ffi::PA_AUDIO_SCIENCE_HPI
 }
 
 /// A structure containing information about a particular host API.


### PR DESCRIPTION
By the way, rustc gives `should have uppercase name` warnings on each of those ffi consts - is there any reason they're not uppercase? If not, I'd be happy to change those too :+1:
