### PR TITLE
Removed Pa prefix from type names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "rust-portaudio"
+version = "0.3.0"
+

--- a/src/asio.rs
+++ b/src/asio.rs
@@ -32,10 +32,10 @@ use ffi;
 use pa::*;
 
 pub trait Asio {
-    fn set_stream_sample_rate(&self, sampleRate : f64) -> PaError;
+    fn set_stream_sample_rate(&self, sampleRate : f64) -> Error;
 }
 
-impl<I, O> Asio for PaStream<I, O> {
+impl<I, O> Asio for Stream<I, O> {
     /**
     * Set the sample rate of an open paASIO stream.
     * 
@@ -81,7 +81,7 @@ pub fn get_available_buffer_sizes(device : PaDeviceIndex) -> Result<(i32, i32, i
 *
 * The string will be no longer than 32 characters including the null terminator.
 */
-pub fn get_input_channel_name(device : PaDeviceIndex, channel_index : i32) -> Result<~str, PaError> {
+pub fn get_input_channel_name(device : PaDeviceIndex, channel_index : i32) -> Result<String, PaError> {
     let c_string : *const c_char = ptr::null();
     let err = unsafe {
         ffi::PaAsio_GetInputChannelName(device, channel_index, &mut c_string)
@@ -97,7 +97,7 @@ pub fn get_input_channel_name(device : PaDeviceIndex, channel_index : i32) -> Re
 *
 * The string will be no longer than 32 characters including the null terminator.
 */
-pub fn get_output_channel_name(device : PaDeviceIndex, channel_index : i32) -> Result<~str, PaError> {
+pub fn get_output_channel_name(device : PaDeviceIndex, channel_index : i32) -> Result<String, PaError> {
     let c_string : *const c_char = ptr::null();
     let err = unsafe {
         ffi::PaAsio_GetOutputChannelName(device, channel_index, &mut c_string)

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,6 @@
 //! implementing the std Error trait.
 //!
 
-
 /// Error codes returned by PortAudio functions.
 #[repr(C)]
 #[deriving(Clone, PartialEq, PartialOrd, Show)]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -24,54 +24,54 @@
 use error::Error;
 use libc::{c_char, c_double, c_void};
 
-use types::{PaDeviceIndex, PaHostApiIndex, PaStreamCallbackFlags,
-            PaStreamCallbackTimeInfo, PaStreamInfo, PaTime, PaStreamCallbackResult};
+use types::{DeviceIndex, HostApiIndex, StreamCallbackFlags,
+            StreamCallbackTimeInfo, StreamInfo, Time, StreamCallbackResult};
 
 // Sample format
-pub type PaSampleFormat = u64;
-pub const PA_FLOAT_32: PaSampleFormat = 0x00000001;
-pub const PA_INT_32: PaSampleFormat = 0x00000002;
-// pub const PA_INT_24: PaSampleFormat = 0x00000004;
-pub const PA_INT_16: PaSampleFormat = 0x00000008;
-pub const PA_INT_8: PaSampleFormat = 0x00000010;
-pub const PA_UINT_8: PaSampleFormat = 0x00000020;
-pub const PA_CUSTOM_FORMAT: PaSampleFormat = 0x00010000;
-pub const PA_NON_INTERLEAVED: PaSampleFormat = 0x80000000;
+pub type SampleFormat = u64;
+pub const PA_FLOAT_32: SampleFormat = 0x00000001;
+pub const PA_INT_32: SampleFormat = 0x00000002;
+// pub const PA_INT_24: SampleFormat = 0x00000004;
+pub const PA_INT_16: SampleFormat = 0x00000008;
+pub const PA_INT_8: SampleFormat = 0x00000010;
+pub const PA_UINT_8: SampleFormat = 0x00000020;
+pub const PA_CUSTOM_FORMAT: SampleFormat = 0x00010000;
+pub const PA_NON_INTERLEAVED: SampleFormat = 0x80000000;
 
 // Stream flags
-pub type PaStreamFlags = u64;
-pub const PA_NO_FLAG: PaStreamFlags = 0;
-pub const PA_CLIP_OFF: PaStreamFlags = 0x00000001;
-pub const PA_DITHER_OFF: PaStreamFlags = 0x00000002;
-pub const PA_NEVER_DROP_INPUT: PaStreamFlags = 0x00000004;
-pub const PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK: PaStreamFlags = 0x00000008;
-pub const PA_PLATFORM_SPECIFIC_FLAGS: PaStreamFlags = 0xFFFF0000;
+pub type StreamFlags = u64;
+pub const PA_NO_FLAG: StreamFlags = 0;
+pub const PA_CLIP_OFF: StreamFlags = 0x00000001;
+pub const PA_DITHER_OFF: StreamFlags = 0x00000002;
+pub const PA_NEVER_DROP_INPUT: StreamFlags = 0x00000004;
+pub const PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK: StreamFlags = 0x00000008;
+pub const PA_PLATFORM_SPECIFIC_FLAGS: StreamFlags = 0xFFFF0000;
 
 /// Unchanging unique identifiers for each supported host API
-pub type PaHostApiTypeId = i32;
-pub const PA_IN_DEVELOPMENT: PaHostApiTypeId = 0;
-pub const PA_DIRECT_SOUND: PaHostApiTypeId = 1;
-pub const PA_MME: PaHostApiTypeId = 2;
-pub const PA_ASIO: PaHostApiTypeId = 3;
-pub const PA_SOUND_MANAGER: PaHostApiTypeId = 4;
-pub const PA_CORE_AUDIO: PaHostApiTypeId = 5;
-pub const PA_OSS: PaHostApiTypeId = 7;
-pub const PA_ALSA: PaHostApiTypeId = 8;
-pub const PA_AL: PaHostApiTypeId = 9;
-pub const PA_BE_OS: PaHostApiTypeId = 10;
-pub const PA_WDMKS: PaHostApiTypeId = 11;
-pub const PA_JACK: PaHostApiTypeId = 12;
-pub const PA_WASAPI: PaHostApiTypeId = 13;
-pub const PA_AUDIO_SCIENCE_HPI: PaHostApiTypeId = 14;
+pub type HostApiTypeId = i32;
+pub const PA_IN_DEVELOPMENT: HostApiTypeId = 0;
+pub const PA_DIRECT_SOUND: HostApiTypeId = 1;
+pub const PA_MME: HostApiTypeId = 2;
+pub const PA_ASIO: HostApiTypeId = 3;
+pub const PA_SOUND_MANAGER: HostApiTypeId = 4;
+pub const PA_CORE_AUDIO: HostApiTypeId = 5;
+pub const PA_OSS: HostApiTypeId = 7;
+pub const PA_ALSA: HostApiTypeId = 8;
+pub const PA_AL: HostApiTypeId = 9;
+pub const PA_BE_OS: HostApiTypeId = 10;
+pub const PA_WDMKS: HostApiTypeId = 11;
+pub const PA_JACK: HostApiTypeId = 12;
+pub const PA_WASAPI: HostApiTypeId = 13;
+pub const PA_AUDIO_SCIENCE_HPI: HostApiTypeId = 14;
 
 pub type C_PaStream = c_void;
 
 #[repr(C)]
 pub struct C_PaStreamParameters {
-    pub device : PaDeviceIndex,
+    pub device : DeviceIndex,
     pub channel_count : i32,
-    pub sample_format : PaSampleFormat,
-    pub suggested_latency : PaTime,
+    pub sample_format : SampleFormat,
+    pub suggested_latency : Time,
     pub host_api_specific_stream_info : *mut c_void
 }
 
@@ -79,13 +79,13 @@ pub struct C_PaStreamParameters {
 pub struct C_PaDeviceInfo {
     pub struct_version: i32,
     pub name: *const c_char,
-    pub host_api: PaHostApiIndex,
+    pub host_api: HostApiIndex,
     pub max_input_channels: i32,
     pub max_output_channels: i32,
-    pub default_low_input_latency: PaTime,
-    pub default_low_output_latency: PaTime,
-    pub default_high_input_latency: PaTime,
-    pub default_high_output_latency: PaTime,
+    pub default_low_input_latency: Time,
+    pub default_low_output_latency: Time,
+    pub default_high_input_latency: Time,
+    pub default_high_output_latency: Time,
     pub default_sample_rate: c_double
 }
 
@@ -114,35 +114,35 @@ extern "C" {
     pub fn Pa_GetErrorText(errorCode : Error) -> *const c_char;
     pub fn Pa_Initialize() -> Error;
     pub fn Pa_Terminate() -> Error;
-    pub fn Pa_GetHostApiCount() -> PaHostApiIndex;
-    pub fn Pa_GetDefaultHostApi() -> PaHostApiIndex;
-    pub fn Pa_GetHostApiInfo(hostApi : PaHostApiIndex) -> *const C_PaHostApiInfo;
-    pub fn Pa_HostApiTypeIdToHostApiIndex(type_id : PaHostApiTypeId) -> PaHostApiIndex;
-    pub fn Pa_HostApiDeviceIndexToDeviceIndex(hostApi : PaHostApiIndex, hostApiDeviceIndex : i32) -> PaDeviceIndex;
+    pub fn Pa_GetHostApiCount() -> HostApiIndex;
+    pub fn Pa_GetDefaultHostApi() -> HostApiIndex;
+    pub fn Pa_GetHostApiInfo(hostApi : HostApiIndex) -> *const C_PaHostApiInfo;
+    pub fn Pa_HostApiTypeIdToHostApiIndex(type_id : HostApiTypeId) -> HostApiIndex;
+    pub fn Pa_HostApiDeviceIndexToDeviceIndex(hostApi : HostApiIndex, hostApiDeviceIndex : i32) -> DeviceIndex;
     pub fn Pa_GetLastHostErrorInfo() -> *const C_PaHostErrorInfo;
-    pub fn Pa_GetDeviceCount() -> PaDeviceIndex;
-    pub fn Pa_GetDefaultInputDevice() -> PaDeviceIndex;
-    pub fn Pa_GetDefaultOutputDevice() -> PaDeviceIndex;
-    pub fn Pa_GetDeviceInfo(device : PaDeviceIndex) -> *const C_PaDeviceInfo;
+    pub fn Pa_GetDeviceCount() -> DeviceIndex;
+    pub fn Pa_GetDefaultInputDevice() -> DeviceIndex;
+    pub fn Pa_GetDefaultOutputDevice() -> DeviceIndex;
+    pub fn Pa_GetDeviceInfo(device : DeviceIndex) -> *const C_PaDeviceInfo;
     pub fn Pa_IsFormatSupported(input_parameters : *const C_PaStreamParameters, outputParameters : *const C_PaStreamParameters, sampleRate : c_double) -> Error;
-    pub fn Pa_GetSampleSize(format : PaSampleFormat) -> Error;
+    pub fn Pa_GetSampleSize(format : SampleFormat) -> Error;
     pub fn Pa_Sleep(msec : i32) -> ();
     pub fn Pa_OpenStream(stream : *mut *mut C_PaStream,
                          inputParameters : *const C_PaStreamParameters,
                          outputParameters : *const C_PaStreamParameters,
                          sampleRate : c_double,
                          framesPerBuffer : u32,
-                         streamFlags : PaStreamFlags,
-                         streamCallback : Option<extern "C" fn(*const c_void, *mut c_void, u32, *const PaStreamCallbackTimeInfo, PaStreamCallbackFlags, *mut c_void) -> PaStreamCallbackResult>,
+                         streamFlags : StreamFlags,
+                         streamCallback : Option<extern "C" fn(*const c_void, *mut c_void, u32, *const StreamCallbackTimeInfo, StreamCallbackFlags, *mut c_void) -> StreamCallbackResult>,
                          userData : *mut c_void)
                          -> Error;
     pub fn Pa_OpenDefaultStream(stream : *mut *mut C_PaStream,
                                 numInputChannels : i32,
                                 numOutputChannels : i32,
-                                sampleFormat : PaSampleFormat,
+                                sampleFormat : SampleFormat,
                                 sampleRate : c_double,
                                 framesPerBuffer : u32,
-                                streamCallback : Option<extern "C" fn(*const c_void, *mut c_void, u32, *const PaStreamCallbackTimeInfo, PaStreamCallbackFlags, *mut c_void) -> PaStreamCallbackResult>,
+                                streamCallback : Option<extern "C" fn(*const c_void, *mut c_void, u32, *const StreamCallbackTimeInfo, StreamCallbackFlags, *mut c_void) -> StreamCallbackResult>,
                                 userData : *mut c_void)
                                 -> Error;
     pub fn Pa_CloseStream(stream : *mut C_PaStream) -> Error;
@@ -152,8 +152,8 @@ extern "C" {
     pub fn Pa_AbortStream(stream : *mut C_PaStream) -> Error;
     pub fn Pa_IsStreamStopped(stream : *mut C_PaStream) -> Error;
     pub fn Pa_IsStreamActive(stream : *mut C_PaStream) -> i32;
-    pub fn Pa_GetStreamInfo(stream : *mut C_PaStream) -> *const PaStreamInfo;
-    pub fn Pa_GetStreamTime(stream : *mut C_PaStream) -> PaTime;
+    pub fn Pa_GetStreamInfo(stream : *mut C_PaStream) -> *const StreamInfo;
+    pub fn Pa_GetStreamTime(stream : *mut C_PaStream) -> Time;
     pub fn Pa_GetStreamCpuLoad(stream : *mut C_PaStream) -> c_double;
     pub fn Pa_ReadStream(stream : *mut C_PaStream, buffer : *mut c_void, frames : u32) -> Error;
     pub fn Pa_WriteStream(stream : *mut C_PaStream, buffer : *mut c_void, frames : u32) -> Error;
@@ -163,19 +163,19 @@ extern "C" {
     /*
     * PortAudio Specific ASIO
     */
-    pub fn PaAsio_GetAvailableBufferSizes(device : PaDeviceIndex, minBufferSizeFrames : *mut i32, maxBufferSizeFrames : *mut i32, preferredBufferSizeFrames : *mut i32, granularity : *mut i32) -> Error;
-    pub fn PaAsio_GetInputChannelName(device : PaDeviceIndex, channelIndex : i32, channelName : *mut *const c_char) -> Error;
-    pub fn PaAsio_GetOutputChannelName(device : PaDeviceIndex, channelIndex : i32, channelName : *mut *const c_char) -> Error;
+    pub fn PaAsio_GetAvailableBufferSizes(device : DeviceIndex, minBufferSizeFrames : *mut i32, maxBufferSizeFrames : *mut i32, preferredBufferSizeFrames : *mut i32, granularity : *mut i32) -> Error;
+    pub fn PaAsio_GetInputChannelName(device : DeviceIndex, channelIndex : i32, channelName : *mut *const c_char) -> Error;
+    pub fn PaAsio_GetOutputChannelName(device : DeviceIndex, channelIndex : i32, channelName : *mut *const c_char) -> Error;
     pub fn PaAsio_SetStreamSampleRate(stream : *mut C_PaStream, sampleRate : c_double) -> Error;
 
 
     /*
     * PortAudio Specific MAC_CORE
     */
-    pub fn PaMacCore_GetStreamInputDevice(s : *mut C_PaStream) -> PaDeviceIndex;
-    pub fn PaMacCore_GetStreamOutputDevice(s : *mut C_PaStream) -> PaDeviceIndex;
+    pub fn PaMacCore_GetStreamInputDevice(s : *mut C_PaStream) -> DeviceIndex;
+    pub fn PaMacCore_GetStreamOutputDevice(s : *mut C_PaStream) -> DeviceIndex;
     // pub fn PaMacCore_GetChannelName (int device, int channelIndex, bool intput) -> *c_char
-    pub fn PaMacCore_GetBufferSizeRange(device : PaDeviceIndex, minBufferSizeFrames : *mut u32, maxBufferSizeFrames : *mut u32) -> Error;
+    pub fn PaMacCore_GetBufferSizeRange(device : DeviceIndex, minBufferSizeFrames : *mut u32, maxBufferSizeFrames : *mut u32) -> Error;
     //pub fn PaMacCore_SetupStreamInfo(PaMacCoreStreamInfo *data, unsigned long flags) -> ();
     //pub fn PaMacCore_SetupChannelMap(PaMacCoreStreamInfo *data, const SInt32 *const channelMap, unsigned long channelMapSize) -> ();
 }

--- a/src/mac_core.rs
+++ b/src/mac_core.rs
@@ -23,27 +23,29 @@
 * The MAC_CORE specific API.
 */
 
-use pa::*;
-use types::*;
 use ffi;
+use pa::*;
+use types::{
+    DeviceIndex,
+};
 
-pub static PaMacCoreChangeDeviceParameters : u32 = 0x01;
-pub static PaMacCoreFailIfConversionRequired : u32 = 0x02;
-pub static PaMacCoreConversionQualityMin : u32 = 0x0100;
-pub static PaMacCoreConversionQualityMedium : u32 = 0x0200;
-pub static PaMacCoreConversionQualityLow : u32 = 0x0300;
-pub static PaMacCoreConversionQualityHigh : u32 = 0x0400;
-pub static PaMacCoreConversionQualityMax : u32 = 0x0000;
-pub static PaMacCorePlayNice : u32 = 0x00;
-pub static PaMacCorePro : u32 = 0x01;
-pub static PaMacCoreMinimizeCPUButPlayNice : u32 = 0x0100;
-pub static PaMacCoreMinimizeCPU : u32 = 0x0101;
+pub static MacCoreChangeDeviceParameters : u32 = 0x01;
+pub static MacCoreFailIfConversionRequired : u32 = 0x02;
+pub static MacCoreConversionQualityMin : u32 = 0x0100;
+pub static MacCoreConversionQualityMedium : u32 = 0x0200;
+pub static MacCoreConversionQualityLow : u32 = 0x0300;
+pub static MacCoreConversionQualityHigh : u32 = 0x0400;
+pub static MacCoreConversionQualityMax : u32 = 0x0000;
+pub static MacCorePlayNice : u32 = 0x00;
+pub static MacCorePro : u32 = 0x01;
+pub static MacCoreMinimizeCPUButPlayNice : u32 = 0x0100;
+pub static MacCoreMinimizeCPU : u32 = 0x0101;
 
 
 /// Not implemented
-pub struct PaMacCoreStreamInfo {
+pub struct MacCoreStreamInfo {
     size : u32,
-    host_api_type : PaHostApiTypeId,
+    host_api_type : HostApiTypeId,
     version : u32,
     flags : u32,
     channel_map : *const i32,
@@ -51,8 +53,8 @@ pub struct PaMacCoreStreamInfo {
 }
 
 pub trait MacCore {
-    fn get_stream_input_device(&self) -> PaDeviceIndex;
-    fn get_stream_output_device(&self) -> PaDeviceIndex; 
+    fn get_stream_input_device(&self) -> DeviceIndex;
+    fn get_stream_output_device(&self) -> DeviceIndex; 
 }
 
 // // fn get_buffer_size_range(device : PaDeviceIndex) -> Result<(u32, u32), PaError> {
@@ -66,13 +68,13 @@ pub trait MacCore {
 // }
 
 
-impl<S> MacCore for PaStream<S> {
-        fn get_stream_input_device(&self) -> PaDeviceIndex {
+impl<S> MacCore for Stream<S> {
+        fn get_stream_input_device(&self) -> DeviceIndex {
         unsafe {
             ffi::PaMacCore_GetStreamInputDevice(self.get_c_pa_stream())
         }
     }
-        fn get_stream_output_device(&self) -> PaDeviceIndex {
+        fn get_stream_output_device(&self) -> DeviceIndex {
         unsafe {
             ffi::PaMacCore_GetStreamOutputDevice(self.get_c_pa_stream())
         }

--- a/src/pa/device.rs
+++ b/src/pa/device.rs
@@ -30,7 +30,7 @@ use ffi;
 /// Return A non-negative value indicating the number of available devices or,
 /// a PaErrorCode (which are always negative) if PortAudio is not initialized or
 /// an error is encountered.
-pub fn get_count() -> PaDeviceIndex {
+pub fn get_count() -> DeviceIndex {
     unsafe {
         ffi::Pa_GetDeviceCount()
     }
@@ -41,7 +41,7 @@ pub fn get_count() -> PaDeviceIndex {
 ///
 /// Return the default input device index for the default host API, or PaNoDevice
 /// if no default input device is available or an error was encountered
-pub fn get_default_input() -> PaDeviceIndex {
+pub fn get_default_input() -> DeviceIndex {
     unsafe {
         ffi::Pa_GetDefaultInputDevice()
     }
@@ -52,7 +52,7 @@ pub fn get_default_input() -> PaDeviceIndex {
 ///
 /// Return the default output device index for the default host API, or PaNoDevice
 /// if no default output device is available or an error was encountered.
-pub fn get_default_output() -> PaDeviceIndex {
+pub fn get_default_output() -> DeviceIndex {
     unsafe {
         ffi::Pa_GetDefaultOutputDevice()
     }
@@ -66,12 +66,12 @@ pub fn get_default_output() -> PaDeviceIndex {
 ///
 /// Return Some(PaDeviceInfo) or, If the device parameter is out of range the
 /// function returns None.
-pub fn get_info(device: PaDeviceIndex) -> Option<PaDeviceInfo> {
+pub fn get_info(device: DeviceIndex) -> Option<DeviceInfo> {
     let c_info = unsafe { ffi::Pa_GetDeviceInfo(device) };
     if c_info.is_null() {
         None
     }
     else {
-        Some(PaDeviceInfo::wrap(c_info))
+        Some(DeviceInfo::wrap(c_info))
     }
 }

--- a/src/pa/host.rs
+++ b/src/pa/host.rs
@@ -30,7 +30,7 @@ use ffi;
 /// Return a non-negative value indicating the number of available host APIs or,
 /// a PaErrorCode (which are always negative) if PortAudio is not initialized or
 /// an error is encountered.
-pub fn get_api_count() -> PaHostApiIndex {
+pub fn get_api_count() -> HostApiIndex {
     unsafe {
         ffi::Pa_GetHostApiCount()
     }
@@ -43,7 +43,7 @@ pub fn get_api_count() -> PaHostApiIndex {
 /// Return a non-negative value ranging from 0 to (get_host_api_count()-1)
 /// indicating the default host API index or, a PaErrorCode (which are always
 /// negative) if PortAudio is not initialized or an error is encountered.
-pub fn get_default_api() -> PaHostApiIndex {
+pub fn get_default_api() -> HostApiIndex {
     unsafe {
         ffi::Pa_GetDefaultHostApi()
     }
@@ -57,13 +57,13 @@ pub fn get_default_api() -> PaHostApiIndex {
 ///
 /// Return Some(PaHostApiInfo) describing a specific host API. If the hostApi
 /// parameter is out of range or an error is encountered, the function returns None.
-pub fn get_api_info(host_api: PaHostApiIndex) -> Option<PaHostApiInfo> {
+pub fn get_api_info(host_api: HostApiIndex) -> Option<HostApiInfo> {
     let c_host_info = unsafe { ffi::Pa_GetHostApiInfo(host_api) };
     if c_host_info.is_null() {
         None
     }
     else {
-        Some(PaHostApiInfo::wrap(c_host_info))
+        Some(HostApiInfo::wrap(c_host_info))
     }
 }
 
@@ -73,11 +73,10 @@ pub fn get_api_info(host_api: PaHostApiIndex) -> Option<PaHostApiInfo> {
 /// * typde_id - A unique host API identifier belonging to the PaHostApiTypeId
 /// enumeration.
 ///
-/// Return a valid PaHostApiIndex ranging from 0 to (get_host_api_count()-1) or,
+/// Return a valid HostApiIndex ranging from 0 to (get_host_api_count()-1) or,
 /// a PaErrorCode (which are always negative) if PortAudio is not initialized or
 /// an error is encountered.
-pub fn api_type_id_to_host_api_index(type_id: PaHostApiTypeId)
-                                          -> PaHostApiIndex {
+pub fn api_type_id_to_host_api_index(type_id: HostApiTypeId) -> HostApiIndex {
     unsafe {
         ffi::Pa_HostApiTypeIdToHostApiIndex(type_id as i32)
     }
@@ -95,9 +94,8 @@ pub fn api_type_id_to_host_api_index(type_id: PaHostApiTypeId)
 /// Return a non-negative PaDeviceIndex ranging from 0 to (get_device_count()-1)
 /// or, a PaErrorCode (which are always negative) if PortAudio is not initialized
 /// or an error is encountered.
-pub fn api_device_index_to_device_index(host_api: PaHostApiIndex,
-                                             host_api_device_index: int)
-                                             -> PaDeviceIndex {
+pub fn api_device_index_to_device_index(host_api: HostApiIndex,
+                                        host_api_device_index: int) -> DeviceIndex {
     unsafe {
         ffi::Pa_HostApiDeviceIndexToDeviceIndex(host_api,
                                                 host_api_device_index as i32)

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,135 +30,135 @@ use ffi;
 
 /// The type used to refer to audio devices. Values of this type usually range
 /// from 0 to (pa::get_device_count()-1)
-pub type PaDeviceIndex = i32;
-/// A special PaDeviceIndex value indicating that no device is available,
+pub type DeviceIndex = i32;
+/// A special DeviceIndex value indicating that no device is available,
 /// or should be used.
-pub const PA_NO_DEVICE: PaDeviceIndex = -1;
-/// A special PaDeviceIndex value indicating that the device(s) to be used are
+pub const PA_NO_DEVICE: DeviceIndex = -1;
+/// A special DeviceIndex value indicating that the device(s) to be used are
 /// specified in the host api specific stream info structure.
-pub const PA_USE_HOST_API_SPECIFIC_DEVICE_SPECIFICATION: PaDeviceIndex = -2;
+pub const PA_USE_HOST_API_SPECIFIC_DEVICE_SPECIFICATION: DeviceIndex = -2;
 
 /// The type used to enumerate to host APIs at runtime.
 /// Values of this type range from 0 to (pa::get_host_api_count()-1).
-pub type PaHostApiIndex = i32;
+pub type HostApiIndex = i32;
 
 /// The type used to represent monotonic time in seconds.
-pub type PaTime = f64;
+pub type Time = f64;
 
 /// A type used to specify one or more sample formats.
 #[repr(u64)]
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
-pub enum PaSampleFormat {
+pub enum SampleFormat {
     /// 32 bits float sample format
-    PaFloat32 =         ffi::PA_FLOAT_32,
+    Float32 =         ffi::PA_FLOAT_32,
     /// 32 bits int sample format
-    PaInt32 =           ffi::PA_INT_32,
+    Int32 =           ffi::PA_INT_32,
     /// 16 bits int sample format
-    PaInt16 =           ffi::PA_INT_16,
+    Int16 =           ffi::PA_INT_16,
     /// 8 bits int sample format
-    PaInt8 =            ffi::PA_INT_8,
+    Int8 =            ffi::PA_INT_8,
     /// 8 bits unsigned int sample format
-    PaUInt8 =           ffi::PA_UINT_8,
+    UInt8 =           ffi::PA_UINT_8,
     /// Custom sample format
-    PaCustomFormat =    ffi::PA_CUSTOM_FORMAT,
+    CustomFormat =    ffi::PA_CUSTOM_FORMAT,
     /// Non interleaved sample format
-    PaNonInterleaved =  ffi::PA_NON_INTERLEAVED
+    NonInterleaved =  ffi::PA_NON_INTERLEAVED
 }
 
 /// The flags to pass to a stream
 #[repr(u64)]
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
-pub enum PaStreamFlags {
+pub enum StreamFlags {
     /// No flags
-    PaNoFlag =                                  ffi::PA_NO_FLAG,
+    NoFlag =                                  ffi::PA_NO_FLAG,
     /// Disable default clipping of out of range samples.
-    PaClipOff =                                 ffi::PA_CLIP_OFF,
+    ClipOff =                                 ffi::PA_CLIP_OFF,
     /// Disable default dithering.
-    PaDitherOff =                               ffi::PA_DITHER_OFF,
+    DitherOff =                               ffi::PA_DITHER_OFF,
     /// Flag requests that where possible a full duplex stream will not discard overflowed input samples without calling the stream callback.
-    PaNeverDropInput =                          ffi::PA_NEVER_DROP_INPUT,
+    NeverDropInput =                          ffi::PA_NEVER_DROP_INPUT,
     /// Call the stream callback to fill initial output buffers, rather than the default behavior of priming the buffers with zeros (silence)
-    PaPrimeOutputBuffersUsingStreamCallback =   ffi::PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK,
+    PrimeOutputBuffersUsingStreamCallback =   ffi::PA_PRIME_OUTPUT_BUFFERS_USING_STREAM_CALLBACK,
     /// A mask specifying the platform specific bits.
-    PaPlatformSpecificFlags =                   ffi::PA_PLATFORM_SPECIFIC_FLAGS
+    PlatformSpecificFlags =                   ffi::PA_PLATFORM_SPECIFIC_FLAGS
 }
 
 
 #[doc(hidden)]
-pub type PaStreamCallbackFlags = u64;
+pub type StreamCallbackFlags = u64;
 /*
-    pub static PaInputUnderflow : PaStreamCallbackFlags = 0x00000001;
-    pub static PaInputOverflow : PaStreamCallbackFlags = 0x00000002;
-    pub static PaOutputUnderflow : PaStreamCallbackFlags = 0x00000004;
-    pub static PaOutputOverflow : PaStreamCallbackFlags = 0x00000008;
-    pub static PaPrimingOutput : PaStreamCallbackFlags = 0x00000010;
+    pub static InputUnderflow : StreamCallbackFlags = 0x00000001;
+    pub static InputOverflow : StreamCallbackFlags = 0x00000002;
+    pub static OutputUnderflow : StreamCallbackFlags = 0x00000004;
+    pub static OutputOverflow : StreamCallbackFlags = 0x00000008;
+    pub static PrimingOutput : StreamCallbackFlags = 0x00000010;
 */
 
 #[doc(hidden)]
-pub type PaCallbackFunction = extern fn(i : f32) -> PaStreamCallbackResult;
+pub type CallbackFunction = extern fn(i : f32) -> StreamCallbackResult;
 #[doc(hidden)]
 #[repr(C)]
-pub enum PaStreamCallbackResult {
-    PaContinue = 0,
-    PaComplete = 1,
-    PaAbort = 2
+pub enum StreamCallbackResult {
+    Continue = 0,
+    Complete = 1,
+    Abort = 2
 }
 
 /// Unchanging unique identifiers for each supported host API
 #[repr(i32)]
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
-pub enum PaHostApiTypeId {
+pub enum HostApiTypeId {
     /// In development host
-    PaInDevelopment =   ffi::PA_IN_DEVELOPMENT,
+    InDevelopment =   ffi::PA_IN_DEVELOPMENT,
     /// Direct sound
-    PaDirectSound =     ffi::PA_DIRECT_SOUND,
+    DirectSound =     ffi::PA_DIRECT_SOUND,
     /// MMe API
-    PaMME =             ffi::PA_MME,
+    MME =             ffi::PA_MME,
     /// ASIO API
-    PaASIO =            ffi::PA_ASIO,
+    ASIO =            ffi::PA_ASIO,
     /// Sound manager API
-    PaSoundManager =    ffi::PA_SOUND_MANAGER,
+    SoundManager =    ffi::PA_SOUND_MANAGER,
     /// Core Audio API
-    PaCoreAudio =       ffi::PA_CORE_AUDIO,
+    CoreAudio =       ffi::PA_CORE_AUDIO,
     /// OSS API
-    PaOSS =             ffi::PA_OSS,
+    OSS =             ffi::PA_OSS,
     /// Alsa API
-    PaALSA =            ffi::PA_ALSA,
+    ALSA =            ffi::PA_ALSA,
     /// AL API
-    PaAL =              ffi::PA_AL,
+    AL =              ffi::PA_AL,
     /// BeOS API
-    PaBeOS =            ffi::PA_BE_OS,
+    BeOS =            ffi::PA_BE_OS,
     /// WDMKS
-    PaWDMKS =           ffi::PA_WDMKS,
+    WDMKS =           ffi::PA_WDMKS,
     /// Jack API
-    PaJACK =            ffi::PA_JACK,
+    JACK =            ffi::PA_JACK,
     /// WASAPI
-    PaWASAPI =          ffi::PA_WASAPI,
+    WASAPI =          ffi::PA_WASAPI,
     /// Audio Science HPI
-    PaAudioScienceHPI = ffi::PA_AUDIO_SCIENCE_HPI
+    AudioScienceHPI = ffi::PA_AUDIO_SCIENCE_HPI
 }
 
 /// A structure containing information about a particular host API.
-pub struct PaHostApiInfo{
+pub struct HostApiInfo{
     /// The version of the struct
     pub struct_version : int,
     /// The type of the current host
-    pub host_type : PaHostApiTypeId,
+    pub host_type : HostApiTypeId,
     /// The name of the host
     pub name : String,
     /// The total count of device in the host
     pub device_count : int,
     /// The index to the default input device
-    pub default_input_device : PaDeviceIndex,
+    pub default_input_device : DeviceIndex,
     /// The index to the default output device
-    pub default_output_device : PaDeviceIndex
+    pub default_output_device : DeviceIndex
 }
 
 #[doc(hidden)]
-impl PaHostApiInfo {
-    pub fn wrap(c_info : *const ffi::C_PaHostApiInfo) -> PaHostApiInfo {
+impl HostApiInfo {
+    pub fn wrap(c_info : *const ffi::C_PaHostApiInfo) -> HostApiInfo {
         unsafe {
-            PaHostApiInfo {
+            HostApiInfo {
                 struct_version : (*c_info).struct_version as int,
                 host_type : transmute(((*c_info).host_type)),
                 name : string::raw::from_buf((*c_info).name as *const u8),
@@ -183,7 +183,7 @@ impl PaHostApiInfo {
 
 /// Structure used to return information about a host error condition.
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
-pub struct PaHostErrorInfo {
+pub struct HostErrorInfo {
     /// The code of the error
     pub error_code : u32,
     /// The string which explain the error
@@ -191,9 +191,9 @@ pub struct PaHostErrorInfo {
 }
 
 #[doc(hidden)]
-impl PaHostErrorInfo {
-    pub fn wrap(c_error : *const ffi::C_PaHostErrorInfo) -> PaHostErrorInfo {
-        PaHostErrorInfo {
+impl HostErrorInfo {
+    pub fn wrap(c_error : *const ffi::C_PaHostErrorInfo) -> HostErrorInfo {
+        HostErrorInfo {
             error_code : unsafe { (*c_error).error_code },
             error_text : unsafe { string::raw::from_buf((*c_error).error_text as *const u8) }
         }
@@ -210,34 +210,34 @@ impl PaHostErrorInfo {
 /// A structure providing information and capabilities of PortAudio devices.
 /// Devices may support input, output or both input and output.
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
-pub struct PaDeviceInfo {
+pub struct DeviceInfo {
     /// The version of the struct
     pub struct_version : int,
     /// The name of the devie
     pub name : String,
     /// Host API identifier
-    pub host_api : PaHostApiIndex,
+    pub host_api : HostApiIndex,
     /// Maximal number of input channels for this device
     pub max_input_channels : int,
     /// maximal number of output channel for this device
     pub max_output_channels : int,
     /// The default low latency for input with this device
-    pub default_low_input_latency : PaTime,
+    pub default_low_input_latency : Time,
     /// The default low latency for output with this device
-    pub default_low_output_latency : PaTime,
+    pub default_low_output_latency : Time,
     /// The default high latency for input with this device
-    pub default_high_input_latency : PaTime,
+    pub default_high_input_latency : Time,
     /// The default high latency for output with this device
-    pub default_high_output_latency : PaTime,
+    pub default_high_output_latency : Time,
     /// The default sample rate for this device
     pub default_sample_rate : f64
 }
 
 #[doc(hidden)]
-impl PaDeviceInfo {
-    pub fn wrap(c_info : *const ffi::C_PaDeviceInfo) -> PaDeviceInfo {
+impl DeviceInfo {
+    pub fn wrap(c_info : *const ffi::C_PaDeviceInfo) -> DeviceInfo {
         unsafe {
-            PaDeviceInfo {
+            DeviceInfo {
                 struct_version : (*c_info).struct_version as int,
                 name : string::raw::from_buf((*c_info).name as *const u8),
                 host_api : (*c_info).host_api,
@@ -270,22 +270,22 @@ impl PaDeviceInfo {
 
 /// Parameters for one direction (input or output) of a stream.
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
-pub struct PaStreamParameters {
+pub struct StreamParameters {
     /// Index of the device
-    pub device : PaDeviceIndex,
+    pub device : DeviceIndex,
     /// The number of channels for this device
     pub channel_count : i32,
     /// Sample format of the device
-    pub sample_format : PaSampleFormat,
+    pub sample_format : SampleFormat,
     /// The suggested latency for this device
-    pub suggested_latency : PaTime,
+    pub suggested_latency : Time,
 }
 
 #[doc(hidden)]
-impl PaStreamParameters {
-    pub fn wrap(c_parameters : *mut ffi::C_PaStreamParameters) -> PaStreamParameters {
+impl StreamParameters {
+    pub fn wrap(c_parameters : *mut ffi::C_PaStreamParameters) -> StreamParameters {
         unsafe {
-            PaStreamParameters {
+            StreamParameters {
                 device : (*c_parameters).device,
                 channel_count : (*c_parameters).channel_count,
                 sample_format : transmute((*c_parameters).sample_format),
@@ -298,7 +298,7 @@ impl PaStreamParameters {
         ffi::C_PaStreamParameters {
             device : self.device,
             channel_count : self.channel_count as i32,
-            sample_format : self.sample_format as ffi::PaSampleFormat,
+            sample_format : self.sample_format as ffi::SampleFormat,
             suggested_latency : self.suggested_latency,
             host_api_specific_stream_info : ptr::null_mut()
         }
@@ -308,22 +308,22 @@ impl PaStreamParameters {
 
 #[doc(hidden)]
 #[repr(C)]
-pub struct PaStreamCallbackTimeInfo {
-    pub input_buffer_adc_time : PaTime,
-    pub current_time : PaTime,
-    pub output_buffer_dac_time : PaTime
+pub struct StreamCallbackTimeInfo {
+    pub input_buffer_adc_time : Time,
+    pub current_time : Time,
+    pub output_buffer_dac_time : Time
 }
 
 /// A structure containing unchanging information about an open stream.
 #[deriving(Clone, PartialEq, PartialOrd, Show)]
 #[repr(C)]
-pub struct PaStreamInfo {
+pub struct StreamInfo {
     /// Struct version
     pub struct_version : i32,
     /// The input latency for this open stream
-    pub input_latency : PaTime,
+    pub input_latency : Time,
     /// The output latency for this open stream
-    pub output_latency : PaTime,
+    pub output_latency : Time,
     /// The sample rate for this open stream
     pub sample_rate : f64
 }

--- a/src/user_traits.rs
+++ b/src/user_traits.rs
@@ -25,12 +25,12 @@
 *
 */
 
-use types::*;
+use types::StreamCallbackResult;
 
 pub trait PortaudioCallback {
     /**
     *
     * T = type defined by PaSampleFormat
     */
-    fn callback_function(&self, input_buffer : ~[f32], frames_per_buffer : u32) -> (PaStreamCallbackResult, ~[f32]);
+    fn callback_function(&self, input_buffer : Box<[f32]>, frames_per_buffer : u32) -> (StreamCallbackResult, Box<[f32]>);
 }


### PR DESCRIPTION
Pretty straight forward! Will probably cause a few breakages for users, but are easy fixes
