### PR TITLE
Updates to rustc 1.0 alpha

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -30,7 +30,7 @@ fn main() -> () {
     }
 
     let type_id = pa::host::api_type_id_to_host_api_index(pa::HostApiTypeId::CoreAudio) as int;
-    println!("PortAudio type id : {}", type_id)
+    println!("PortAudio type id : {}", type_id);
 
     let def_input = pa::device::get_default_input();
     let input_info = match pa::device::get_info(def_input) {

--- a/src/ext/mac_core.rs
+++ b/src/ext/mac_core.rs
@@ -46,7 +46,7 @@ pub static MacCoreMinimizeCPU : u32 = 0x0101;
 
 /// Not implemented
 #[allow(raw_pointer_deriving)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct MacCoreStreamInfo {
     size : u32,
     host_api_type : HostApiTypeId,

--- a/src/ext/mac_core.rs
+++ b/src/ext/mac_core.rs
@@ -45,7 +45,7 @@ pub static MacCoreMinimizeCPU : u32 = 0x0101;
 
 
 /// Not implemented
-#[allow(raw_pointer_deriving)]
+#[allow(raw_pointer_derive)]
 #[derive(Copy)]
 pub struct MacCoreStreamInfo {
     size : u32,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -23,6 +23,8 @@
 
 use pa::error::Error;
 use libc::{c_char, c_double, c_void};
+use std;
+use std::ffi::CString;
 
 use pa::{
     DeviceIndex,
@@ -183,4 +185,16 @@ extern "C" {
     pub fn PaMacCore_GetBufferSizeRange(device : DeviceIndex, minBufferSizeFrames : *mut u32, maxBufferSizeFrames : *mut u32) -> Error;
     //pub fn PaMacCore_SetupStreamInfo(PaMacCoreStreamInfo *data, unsigned long flags) -> ();
     //pub fn PaMacCore_SetupChannelMap(PaMacCoreStreamInfo *data, const SInt32 *const channelMap, unsigned long channelMapSize) -> ();
+}
+
+/// A function to convert C strings to Rust strings
+pub fn c_str_to_string<'a>(c_str: &'a *const c_char) -> String
+{
+    unsafe {String::from_utf8_lossy(std::ffi::c_str_to_bytes(c_str)).into_owned() }
+}
+
+/// A function to convert Rust strings to C strings
+pub fn string_to_c_str(rust_str: &String) -> *const c_char
+{
+    CString::from_slice(rust_str.as_bytes()).as_ptr()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -74,7 +74,7 @@ pub const PA_AUDIO_SCIENCE_HPI: HostApiTypeId = 14;
 pub type C_PaStream = c_void;
 
 #[allow(raw_pointer_deriving)]
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub struct C_PaStreamParameters {
     pub device : DeviceIndex,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -75,7 +75,7 @@ pub const PA_AUDIO_SCIENCE_HPI: HostApiTypeId = 14;
 
 pub type C_PaStream = c_void;
 
-#[allow(raw_pointer_deriving)]
+#[allow(raw_pointer_derive)]
 #[derive(Copy)]
 #[repr(C)]
 pub struct C_PaStreamParameters {

--- a/src/pa/error.rs
+++ b/src/pa/error.rs
@@ -4,7 +4,7 @@
 //!
 
 /// Error codes returned by PortAudio functions.
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Show, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Show, FromPrimitive)]
 #[repr(C)]
 pub enum Error {
     /// No Error

--- a/src/pa/host.rs
+++ b/src/pa/host.rs
@@ -100,9 +100,8 @@ pub fn api_type_id_to_host_api_index(type_id: HostApiTypeId) -> HostApiIndex {
 /// or, a PaErrorCode (which are always negative) if PortAudio is not initialized
 /// or an error is encountered.
 pub fn api_device_index_to_device_index(host_api: HostApiIndex,
-                                        host_api_device_index: int) -> DeviceIndex {
+                                        host_api_device_index: i32) -> DeviceIndex {
     unsafe {
-        ffi::Pa_HostApiDeviceIndexToDeviceIndex(host_api,
-                                                host_api_device_index as i32)
+        ffi::Pa_HostApiDeviceIndexToDeviceIndex(host_api, host_api_device_index)
     }
 }

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -23,6 +23,7 @@
 
 use std::{ptr, mem};
 use std::mem::{transmute};
+use std::num::{FromPrimitive};
 use std::vec::{Vec};
 use libc::{c_double, c_void, malloc};
 use libc::types::os::arch::c95::size_t;
@@ -199,12 +200,13 @@ pub fn sleep(m_sec : int) -> () {
 
 mod private {
 
+    use std::num::{FromPrimitive, ToPrimitive};
+    use std::ops::{Add, Sub, Mul, Div};
     use super::types::SampleFormat;
 
     /// internal private trait for Sample format management
     pub trait SamplePrivate: ::std::default::Default + Copy + Clone + ::std::fmt::Show
-                             + ToPrimitive + FromPrimitive + Add<Self, Self>
-                             + Sub<Self, Self> + Mul<Self, Self> + Div<Self, Self> {
+                             + ToPrimitive + FromPrimitive + Add + Sub + Mul + Div {
         /// return the size of a sample format
         fn size<S: SamplePrivate>() -> uint {
             ::std::mem::size_of::<S>()

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -66,7 +66,7 @@ pub fn get_version() -> i32 {
 /// Retrieve a textual description of the current PortAudio build.
 pub fn get_version_text() -> String {
     unsafe {
-        String::from_raw_buf(ffi::Pa_GetVersionText() as *const u8)
+        ffi::c_str_to_string(&ffi::Pa_GetVersionText())
     }
 }
 
@@ -78,7 +78,7 @@ pub fn get_version_text() -> String {
 /// Return the error as a string.
 pub fn get_error_text(error_code: Error) -> String {
     unsafe {
-        String::from_raw_buf(ffi::Pa_GetErrorText(error_code) as *const u8)
+        ffi::c_str_to_string(&ffi::Pa_GetErrorText(error_code))
     }
 }
 
@@ -559,7 +559,7 @@ impl<I: Sample, O: Sample> Stream<I, O> {
         };
         Ok(unsafe {
             Vec::from_raw_buf(self.unsafe_buffer as *const I,
-                              frames_per_buffer * self.num_input_channels) })
+                              (frames_per_buffer as usize) * (self.num_input_channels as usize)) })
     }
 
     /// Read samples from an input stream.

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -192,9 +192,9 @@ pub fn get_sample_size(format: SampleFormat) -> Result<(), Error> {
 ///
 /// The function may sleep longer than requested so don't rely on this for
 /// accurate musical timing.
-pub fn sleep(m_sec : int) -> () {
+pub fn sleep(m_sec : i32) -> () {
     unsafe {
-        ffi::Pa_Sleep(m_sec as i32)
+        ffi::Pa_Sleep(m_sec)
     }
 }
 
@@ -208,7 +208,7 @@ mod private {
     pub trait SamplePrivate: ::std::default::Default + Copy + Clone + ::std::fmt::Show
                              + ToPrimitive + FromPrimitive + Add + Sub + Mul + Div {
         /// return the size of a sample format
-        fn size<S: SamplePrivate>() -> uint {
+        fn size<S: SamplePrivate>() -> usize {
             ::std::mem::size_of::<S>()
         }
         /// get the sample format
@@ -559,7 +559,7 @@ impl<I: Sample, O: Sample> Stream<I, O> {
         };
         Ok(unsafe {
             Vec::from_raw_buf(self.unsafe_buffer as *const I,
-                              (frames_per_buffer * self.num_input_channels as u32) as uint) })
+                              frames_per_buffer * self.num_input_channels) })
     }
 
     /// Read samples from an input stream.

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -25,6 +25,7 @@
 
 use std::ptr;
 use std::mem::{transmute};
+use std::c_str::ToCStr;
 
 use ffi;
 

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -25,7 +25,6 @@
 
 use std::ptr;
 use std::mem::{transmute};
-use std::c_str::ToCStr;
 
 use ffi;
 
@@ -168,7 +167,7 @@ impl HostApiInfo {
             HostApiInfo {
                 struct_version : (*c_info).struct_version,
                 host_type : transmute(((*c_info).host_type)),
-                name : String::from_raw_buf((*c_info).name as *const u8),
+                name : ffi::c_str_to_string(&(*c_info).name),
                 device_count : (*c_info).device_count,
                 default_input_device : (*c_info).default_input_device,
                 default_output_device : (*c_info).default_output_device
@@ -180,7 +179,7 @@ impl HostApiInfo {
         ffi::C_PaHostApiInfo {
             struct_version : self.struct_version as i32,
             host_type : self.host_type as i32,
-            name : unsafe { self.name.to_c_str().into_inner() },
+            name : unsafe { ffi::string_to_c_str(&self.name) },
             device_count : self.device_count as i32,
             default_input_device : self.default_input_device as i32,
             default_output_device : self.default_output_device as i32
@@ -202,14 +201,14 @@ impl HostErrorInfo {
     pub fn wrap(c_error : *const ffi::C_PaHostErrorInfo) -> HostErrorInfo {
         HostErrorInfo {
             error_code : unsafe { (*c_error).error_code },
-            error_text : unsafe { String::from_raw_buf((*c_error).error_text as *const u8) }
+            error_text : unsafe { ffi::c_str_to_string(&(*c_error).error_text) }
         }
     }
 
     pub fn unwrap(&self) -> ffi::C_PaHostErrorInfo {
         ffi::C_PaHostErrorInfo {
             error_code : self.error_code,
-            error_text : unsafe { self.error_text.to_c_str().into_inner() }
+            error_text : unsafe { ffi::string_to_c_str(&self.error_text) }
         }
     }
 }
@@ -246,7 +245,7 @@ impl DeviceInfo {
         unsafe {
             DeviceInfo {
                 struct_version : (*c_info).struct_version,
-                name : String::from_raw_buf((*c_info).name as *const u8),
+                name : ffi::c_str_to_string(&(*c_info).name),
                 host_api : (*c_info).host_api,
                 max_input_channels : (*c_info).max_input_channels,
                 max_output_channels : (*c_info).max_output_channels,
@@ -262,7 +261,7 @@ impl DeviceInfo {
     pub fn unwrap(&self) -> ffi::C_PaDeviceInfo {
         ffi::C_PaDeviceInfo {
             struct_version : self.struct_version as i32,
-            name : unsafe { self.name.to_c_str().into_inner() },
+            name : unsafe { ffi::string_to_c_str(&self.name) },
             host_api : self.host_api,
             max_input_channels : self.max_input_channels as i32,
             max_output_channels : self.max_output_channels as i32,
@@ -335,4 +334,3 @@ pub struct StreamInfo {
     /// The sample rate for this open stream
     pub sample_rate : f64
 }
-

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -148,13 +148,13 @@ pub enum HostApiTypeId {
 /// A structure containing information about a particular host API.
 pub struct HostApiInfo{
     /// The version of the struct
-    pub struct_version : int,
+    pub struct_version : i32,
     /// The type of the current host
     pub host_type : HostApiTypeId,
     /// The name of the host
     pub name : String,
     /// The total count of device in the host
-    pub device_count : int,
+    pub device_count : i32,
     /// The index to the default input device
     pub default_input_device : DeviceIndex,
     /// The index to the default output device
@@ -166,10 +166,10 @@ impl HostApiInfo {
     pub fn wrap(c_info : *const ffi::C_PaHostApiInfo) -> HostApiInfo {
         unsafe {
             HostApiInfo {
-                struct_version : (*c_info).struct_version as int,
+                struct_version : (*c_info).struct_version,
                 host_type : transmute(((*c_info).host_type)),
                 name : String::from_raw_buf((*c_info).name as *const u8),
-                device_count : (*c_info).device_count as int,
+                device_count : (*c_info).device_count,
                 default_input_device : (*c_info).default_input_device,
                 default_output_device : (*c_info).default_output_device
             }
@@ -219,15 +219,15 @@ impl HostErrorInfo {
 #[derive(Clone, PartialEq, PartialOrd, Show)]
 pub struct DeviceInfo {
     /// The version of the struct
-    pub struct_version : int,
+    pub struct_version : i32,
     /// The name of the devie
     pub name : String,
     /// Host API identifier
     pub host_api : HostApiIndex,
     /// Maximal number of input channels for this device
-    pub max_input_channels : int,
+    pub max_input_channels : i32,
     /// maximal number of output channel for this device
-    pub max_output_channels : int,
+    pub max_output_channels : i32,
     /// The default low latency for input with this device
     pub default_low_input_latency : Time,
     /// The default low latency for output with this device
@@ -245,11 +245,11 @@ impl DeviceInfo {
     pub fn wrap(c_info : *const ffi::C_PaDeviceInfo) -> DeviceInfo {
         unsafe {
             DeviceInfo {
-                struct_version : (*c_info).struct_version as int,
+                struct_version : (*c_info).struct_version,
                 name : String::from_raw_buf((*c_info).name as *const u8),
                 host_api : (*c_info).host_api,
-                max_input_channels : (*c_info).max_input_channels as int,
-                max_output_channels : (*c_info).max_output_channels as int,
+                max_input_channels : (*c_info).max_input_channels,
+                max_output_channels : (*c_info).max_output_channels,
                 default_low_input_latency : (*c_info).default_low_input_latency,
                 default_low_output_latency : (*c_info).default_low_output_latency,
                 default_high_input_latency : (*c_info).default_high_input_latency,

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -52,7 +52,7 @@ pub type Frames = i64;
 
 /// A type used to specify one or more sample formats.
 #[repr(u64)]
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Show)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Show)]
 pub enum SampleFormat {
     /// 32 bits float sample format
     Float32 =         ffi::PA_FLOAT_32,
@@ -72,7 +72,7 @@ pub enum SampleFormat {
 
 /// The flags to pass to a stream
 #[repr(u64)]
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Show)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Show)]
 pub enum StreamFlags {
     /// No flags
     NoFlag =                                  ffi::PA_NO_FLAG,
@@ -102,7 +102,7 @@ pub type StreamCallbackFlags = u64;
 #[doc(hidden)]
 pub type CallbackFunction = extern fn(i : f32) -> StreamCallbackResult;
 #[doc(hidden)]
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub enum StreamCallbackResult {
     Continue = 0,
@@ -112,7 +112,7 @@ pub enum StreamCallbackResult {
 
 /// Unchanging unique identifiers for each supported host API
 #[repr(i32)]
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Show)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Show)]
 pub enum HostApiTypeId {
     /// In development host
     InDevelopment =   ffi::PA_IN_DEVELOPMENT,
@@ -188,7 +188,7 @@ impl HostApiInfo {
 }
 
 /// Structure used to return information about a host error condition.
-#[deriving(Clone, PartialEq, PartialOrd, Show)]
+#[derive(Clone, PartialEq, PartialOrd, Show)]
 pub struct HostErrorInfo {
     /// The code of the error
     pub error_code : u32,
@@ -215,7 +215,7 @@ impl HostErrorInfo {
 
 /// A structure providing information and capabilities of PortAudio devices.
 /// Devices may support input, output or both input and output.
-#[deriving(Clone, PartialEq, PartialOrd, Show)]
+#[derive(Clone, PartialEq, PartialOrd, Show)]
 pub struct DeviceInfo {
     /// The version of the struct
     pub struct_version : int,
@@ -275,7 +275,7 @@ impl DeviceInfo {
 }
 
 /// Parameters for one direction (input or output) of a stream.
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Show)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Show)]
 pub struct StreamParameters {
     /// Index of the device
     pub device : DeviceIndex,
@@ -313,7 +313,7 @@ impl StreamParameters {
 
 
 #[doc(hidden)]
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub struct StreamCallbackTimeInfo {
     pub input_buffer_adc_time : Time,
@@ -322,7 +322,7 @@ pub struct StreamCallbackTimeInfo {
 }
 
 /// A structure containing unchanging information about an open stream.
-#[deriving(Copy, Clone, PartialEq, PartialOrd, Show)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Show)]
 #[repr(C)]
 pub struct StreamInfo {
     /// Struct version

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -179,7 +179,7 @@ impl HostApiInfo {
         ffi::C_PaHostApiInfo {
             struct_version : self.struct_version as i32,
             host_type : self.host_type as i32,
-            name : unsafe { ffi::string_to_c_str(&self.name) },
+            name : ffi::string_to_c_str(&self.name),
             device_count : self.device_count as i32,
             default_input_device : self.default_input_device as i32,
             default_output_device : self.default_output_device as i32
@@ -208,7 +208,7 @@ impl HostErrorInfo {
     pub fn unwrap(&self) -> ffi::C_PaHostErrorInfo {
         ffi::C_PaHostErrorInfo {
             error_code : self.error_code,
-            error_text : unsafe { ffi::string_to_c_str(&self.error_text) }
+            error_text : ffi::string_to_c_str(&self.error_text)
         }
     }
 }
@@ -261,7 +261,7 @@ impl DeviceInfo {
     pub fn unwrap(&self) -> ffi::C_PaDeviceInfo {
         ffi::C_PaDeviceInfo {
             struct_version : self.struct_version as i32,
-            name : unsafe { ffi::string_to_c_str(&self.name) },
+            name : ffi::string_to_c_str(&self.name),
             host_api : self.host_api,
             max_input_channels : self.max_input_channels as i32,
             max_output_channels : self.max_output_channels as i32,


### PR DESCRIPTION
Breaking changes in rustc have created the following issues:

1. Macros must be followed by semicolons.
2. Many traits are no longer automatically exported from std, and must manually be namespaced or imported.
3. `#[deriving(Trait)]` has been renamed to `#[derive(Trait)]`.
4. Types `int/uint` have been deprecated.
5. The `std::ffi` library was overhauled, and converting from `c_str` to `String` was broken.