### PR TITLE
Updated to latest rustc

### DIFF
--- a/src/pa/error.rs
+++ b/src/pa/error.rs
@@ -4,7 +4,7 @@
 //!
 
 /// Error codes returned by PortAudio functions.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Show, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, FromPrimitive)]
 #[repr(C)]
 pub enum Error {
     /// No Error
@@ -67,6 +67,12 @@ pub enum Error {
     IncompatibleStreamHostApi,
     /// Invalid buffer
     BadBufferPtr,
+}
+
+impl ::std::fmt::Display for Error {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+        self.fmt(f)
+    }
 }
 
 impl ::std::error::Error for Error {

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -205,7 +205,7 @@ mod private {
     use super::types::SampleFormat;
 
     /// internal private trait for Sample format management
-    pub trait SamplePrivate: ::std::default::Default + Copy + Clone + ::std::fmt::Show
+    pub trait SamplePrivate: ::std::default::Default + Copy + Clone + ::std::fmt::Debug
                              + ToPrimitive + FromPrimitive + Add + Sub + Mul + Div {
         /// return the size of a sample format
         fn size<S: SamplePrivate>() -> usize {
@@ -579,7 +579,7 @@ impl<I: Sample, O: Sample> Stream<I, O> {
         match err {
             Error::NoError  => Ok(unsafe {
                 Vec::from_raw_buf(self.unsafe_buffer as *const I,
-                        (frames_per_buffer * self.num_input_channels as u32) as uint) }),
+                        (frames_per_buffer * self.num_input_channels as u32) as usize) }),
             _               => Err(err)
         }
     }


### PR DESCRIPTION
Note that the `Display` implementation for `Error` is temporary, as the bound for the `std::error::Error` trait is likely to change from `Display` to `Debug` (which is implemented by doing `derive(Debug)`).