### PR TITLE
Cargo build script - build PA as a static lib + Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ watch.sh
 /examples/**
 !/examples/*.rs
 !/examples/assets/
+.portaudio

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ notifications:
   email:
     - letang.jeremy@gmail.com
 before_install:
-  - yes | sudo add-apt-repository ppa:cmrx64/cargo
   - sudo apt-get update
 install:
   - curl http://static.rust-lang.org/rustup.sh | sudo sh -
   - sudo apt-get install libportaudio-dev
-  - sudo apt-get install cargo
-env:
-  - RUST_TEST_TASKS=1
 script:
   - cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,11 @@
 name = "rust-portaudio"
 version = "0.3.0"
 dependencies = [
- "pkg-config 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [root]
 name = "rust-portaudio"
 version = "0.3.0"
+dependencies = [
+ "pkg-config 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ crate-type = ["dylib", "rlib"]
 [[bin]]
 name = "portaudio_example"
 path = "examples/main.rs"
+
+[build-dependencies]
+pkg-config = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,13 @@ version = "0.3.0"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>"]
 description = "Portaudio binding for Rust"
 license = "MIT"
+build = "build.rs"
 
 [lib]
 
 name = "portaudio"
 crate-type = ["dylib", "rlib"]
+
+[[bin]]
+name = "portaudio_example"
+path = "examples/main.rs"

--- a/README.md
+++ b/README.md
@@ -17,21 +17,8 @@ Only the blocking API work for the moment.
 
 # Installation
 
-You must install on your computer the Portaudio libraries who is used for the binding.
+__rust-portaudio__ will try to detect portaudio on your system and, failing that (or if given the `PORTAUDIO_ONLY_STATIC` environment variable on the build process), will download and build portaudio statically.
 
-Portaudio is available with package management tools on Linux, or brew on Mac OS.
+__rust-portaudio__ is built using cargo, so just type `cargo build` at the root of the __rust-portaudio__ repository.
 
-You can download it directly from the website : [portaudio](http://www.portaudio.com/download.html)
-
-Then clone the repo and build the library with the following command at the root of the __rust-portaudio__ repository.
-
-__rust-portaudio__ is build using make, so just type `make` at the root of the __rust-portaudio__ repository, this command
-build __rust-portaudio__, the examples, and the documentation.
-
-You can build them separatly to with the dedicated commands:
-
-```Shell
-> make portaudio
-> make test
-> make doc
-```
+You can build the tests and examples with `cargo test`, and the documentation with `cargo doc`.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,112 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 Jeremy Letang (letang.jeremy@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+fn main() {
+    platform::build();
+}
+
+#[cfg(target_os="macos")]
+mod platform {
+    use std::io::process::Command;
+    use std::path::Path;
+    use std::io::fs::PathExtensions;
+    use std::os;
+
+    const PORTAUDIO_URL: &'static str = "http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz";
+    const PORTAUDIO_TAR: &'static str = "pa_stable_v19_20140130.tgz";
+    const PORTAUDIO_FOLDER: &'static str = "portaudio";
+    const PORTAUDIO_LIB_PATH: &'static str = ".portaudio/lib/.libs/libportaudio.dylib";
+
+    pub fn build() {
+        // retrieve cargo deps out dir
+        let out_dir = os::getenv("OUT_DIR").unwrap();
+
+        // check if the .portaudio folder exist
+        let fld: Path = Path::new_opt(".portaudio").unwrap();
+
+        if !fld.is_dir() {
+            build_osx_portaudio();
+        }
+
+        // move portaudio library inside the OUT_DIR folder
+        match Command::new("cp").arg(PORTAUDIO_LIB_PATH).arg(out_dir.clone()).output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        println!("cargo:rustc-flags=-L {} -l portaudio", out_dir);
+    }
+
+    fn build_osx_portaudio() {
+        // get portaudio library sources
+        match Command::new("wget").arg(PORTAUDIO_URL).output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // untar portaudio sources
+        match Command::new("tar").arg("xvf").arg(PORTAUDIO_TAR).output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // change dir to the portaudio folder
+        match os::change_dir(&from_str(PORTAUDIO_FOLDER).unwrap()) {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // run portaudio autoconf
+        match Command::new("./configure").output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // then make
+        match Command::new("make").output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // return to rust-portaudio root
+        match os::change_dir(&from_str("..").unwrap()) {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // cleaning portaudio sources
+        match Command::new("rm").arg("-rf").arg(PORTAUDIO_TAR).output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+
+        // cleaning portaudio sources
+        match Command::new("mv").arg(PORTAUDIO_FOLDER).arg(".portaudio").output() {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e)
+        }
+    }
+}
+
+#[cfg(any(target_os="linux", target_os="win32"))]
+mod platform {
+    pub fn build() {}
+}

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#![feature(io, env, path, fs)]
+#![feature(io, env, path, fs, os)]
 
 extern crate "pkg-config" as pkg_config;
 
@@ -30,7 +30,7 @@ use std::env;
 use unix_platform as platform;
 
 fn main() {
-    if env::var("PORTAUDIO_ONLY_STATIC").is_none() {
+    if env::var("PORTAUDIO_ONLY_STATIC").is_err() {
         // If pkg-config finds a library on the system, we are done
         if pkg_config::Config::new().atleast_version("19").find("portaudio-2.0").is_ok() {
             return;

--- a/build.rs
+++ b/build.rs
@@ -30,9 +30,11 @@ use std::env;
 use unix_platform as platform;
 
 fn main() {
-    // If pkg-config finds a library on the system, we are done
-    if pkg_config::Config::new().atleast_version("19").find("portaudio-2.0").is_ok() {
-        return;
+    if env::var("PORTAUDIO_ONLY_STATIC").is_none() {
+        // If pkg-config finds a library on the system, we are done
+        if pkg_config::Config::new().atleast_version("19").find("portaudio-2.0").is_ok() {
+            return;
+        }
     }
 
     build();


### PR DESCRIPTION
This PR contains a squash of #37 plus my own changes to make it play nicely with Linux's `pkg-config`.

This downloads and builds portaudio as a static library (unless it is found on the system via `pkg-config`), taking care to use `pkg-config` on linux to pick up extra dependencies (such as `libasound`).

I tested this on Ubuntu 14.04 and Fedora 21. OS X was reportedly working fine on #37, but it would be great if someone could test it again to make sure I didn't break anything :)

Fixes #33 