### PR TITLE
Silenced build script io/path warnings and fixed example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ watch.sh
 !/examples/*.rs
 !/examples/assets/
 .portaudio
+Cargo.lock

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#![feature(io, env, path, fs, os)]
+#![feature(old_io, old_path, env, path, fs, os)]
 
 extern crate "pkg-config" as pkg_config;
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -100,10 +100,10 @@ fn main() {
     // Now start the main read/write loop! In this example, we pass the input buffer directly to
     // the output buffer, so watch out for feedback.
     'stream: loop {
-        wait_for_stream(|&:| stream.get_stream_read_available(), "Read");
+        wait_for_stream(|| stream.get_stream_read_available(), "Read");
         match stream.read(FRAMES) {
             Ok(input_samples)  => {
-                wait_for_stream(|&:| stream.get_stream_write_available(), "Write");
+                wait_for_stream(|| stream.get_stream_write_available(), "Write");
                 match stream.write(input_samples, FRAMES) {
                     Ok(()) => (),
                     Err(err) => {

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,4 +1,3 @@
-#![allow(unreachable_code, unused_assignments)]
 #![feature(core)]
 
 extern crate portaudio;
@@ -9,7 +8,7 @@ use std::error::Error;
 const SAMPLE_RATE: f64 = 44_100.0;
 const FRAMES: u32 = 256;
 
-fn main() -> () {
+fn main() {
 
     println!("PortAudio version : {}", pa::get_version());
     println!("PortAudio version text : {}", pa::get_version_text());


### PR DESCRIPTION
@renato-zannon do you happen to know much about the new `std::io`/`path` ? If so, d'you think you could update your build script to use it? Cheers!