### PR TITLE
Updated to latest rustc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,9 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#![feature(path, path_ext, os)]
+#![feature(path_ext, os)]
 
-extern crate "pkg-config" as pkg_config;
+extern crate pkg_config;
 
 use std::path::Path;
 use std::fs::PathExt;

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,4 +1,3 @@
-#![feature(core)]
 
 extern crate portaudio;
 

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -597,11 +597,10 @@ impl<I: Sample, O: Sample> Stream<I, O> {
     /// * frames_per_buffer - The number of frames in the buffer.
     ///
     /// Return NoError on success, or a Error code if fail.
-    pub fn write<T> (&self, output_buffer: T, frames_per_buffer : u32) -> Result<(), Error>
-    where T: AsSlice<O> {
+    pub fn write(&self, output_buffer: Vec<O>, frames_per_buffer : u32) -> Result<(), Error> {
         match unsafe {
             ffi::Pa_WriteStream(self.c_pa_stream,
-                                output_buffer.as_slice().as_ptr() as *mut c_void,
+                                output_buffer[..].as_ptr() as *mut c_void,
                                 frames_per_buffer)
         } {
             Error::NoError => Ok(()),


### PR DESCRIPTION
Changed write to take a `Vec<Sample>` rather than a generic `T: AsSlice<Sample>` as `AsSlice` has been deprecated, and their doesn't yet seem to be a suitable replacement. Vec seems to be exclusively used anyway.