### PR TITLE
Added StreamAvailable struct for handling both frame availability and over/underflow.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "portaudio"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>",
            "Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "PortAudio bindings for Rust."

--- a/src/pa/error.rs
+++ b/src/pa/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
     StreamIsNotStopped,
     /// The input stream has overflowed
     InputOverflowed,
-    /// The output has overflowed
+    /// The output has underflowed
     OutputUnderflowed,
     /// The host API is not found by Portaudio
     HostApiNotFound,
@@ -99,7 +99,7 @@ impl ::std::error::Error for Error {
             Error::StreamIsStopped => "The stream is stopped",
             Error::StreamIsNotStopped => "The stream is not stopped",
             Error::InputOverflowed => "The input stream has overflowed",
-            Error::OutputUnderflowed => "The output stream has overflowed",
+            Error::OutputUnderflowed => "The output stream has underflowed",
             Error::HostApiNotFound => "The host api is not found by Portaudio",
             Error::InvalidHostApi => "The host API is invalid",
             Error::CanNotReadFromACallbackStream => "Portaudio cannot read from the callback stream",

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -90,6 +90,18 @@ pub enum StreamFlags {
     PlatformSpecificFlags =                   ffi::PA_PLATFORM_SPECIFIC_FLAGS
 }
 
+/// Describes stream availability and the number for frames available for reading/writing if there
+/// is any.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum StreamAvailable {
+    /// The number of frames available for reading.
+    Frames(i64),
+    /// The input stream has overflowed.
+    InputOverflowed,
+    /// The output stream has underflowed.
+    OutputUnderflowed,
+}
+
 /// A rust enum representation of the C_PaStreamCallbackFlag
 #[repr(u64)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]


### PR DESCRIPTION
- Fixed Error::OutputUnderflowed description error.
- Removed unnecessary macos specific read method.

This *might* be a fix for #72 and #36.

@niclashoyer