### PR TITLE
Use number of frames returned by read/write_available rather than setup FRAMES in blocking.rs example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "portaudio"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>",
            "Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "PortAudio bindings for Rust."

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -706,8 +706,10 @@ impl<I: Sample, O: Sample> Stream<I, O> {
     /// * output_buffer - The buffer contains samples in the format specified by S.
     /// * frames_per_buffer - The number of frames in the buffer.
     ///
-    /// Return NoError on success, or a Error code if fail.
-    pub fn write(&self, output_buffer: Vec<O>, frames_per_buffer : u32) -> Result<Option<WriteFlags>, Error> {
+    /// Returns an Option<WriteFlags> on success and an Error variant on failure.
+    pub fn write(&self,
+                 output_buffer: Vec<O>,
+                 frames_per_buffer : u32) -> Result<Option<WriteFlags>, Error> {
         match unsafe {
             ffi::Pa_WriteStream(self.c_pa_stream,
                                 output_buffer[..].as_ptr() as *mut c_void,

--- a/src/pa/mod.rs
+++ b/src/pa/mod.rs
@@ -48,7 +48,6 @@ pub use self::types::{
     StreamInfo,
     StreamParameters,
     Time,
-    WriteFlags,
     PA_NO_DEVICE,
     PA_USE_HOST_API_SPECIFIC_DEVICE_SPECIFICATION,
 };
@@ -706,18 +705,14 @@ impl<I: Sample, O: Sample> Stream<I, O> {
     /// * output_buffer - The buffer contains samples in the format specified by S.
     /// * frames_per_buffer - The number of frames in the buffer.
     ///
-    /// Returns an Option<WriteFlags> on success and an Error variant on failure.
-    pub fn write(&self,
-                 output_buffer: Vec<O>,
-                 frames_per_buffer : u32) -> Result<Option<WriteFlags>, Error> {
+    /// Returns Ok(()) on success and an Err(Error) variant on failure.
+    pub fn write(&self, output_buffer: Vec<O>, frames_per_buffer : u32) -> Result<(), Error> {
         match unsafe {
             ffi::Pa_WriteStream(self.c_pa_stream,
                                 output_buffer[..].as_ptr() as *mut c_void,
                                 frames_per_buffer)
         } {
-            Error::NoError => Ok(None),
-            Error::OutputUnderflowed => Ok(Some(WriteFlags::OutputUnderflowed)),
-            Error::InputOverflowed => Ok(Some(WriteFlags::InputOverflowed)),
+            Error::NoError => Ok(()),
             err => Err(err),
         }
     }

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -90,8 +90,8 @@ pub enum StreamFlags {
     PlatformSpecificFlags =                   ffi::PA_PLATFORM_SPECIFIC_FLAGS
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
 /// The flags returned after writing to a stream
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum WriteFlags {
     /// The output stream has underflowed.
     OutputUnderflowed,

--- a/src/pa/types.rs
+++ b/src/pa/types.rs
@@ -90,15 +90,6 @@ pub enum StreamFlags {
     PlatformSpecificFlags =                   ffi::PA_PLATFORM_SPECIFIC_FLAGS
 }
 
-/// The flags returned after writing to a stream
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum WriteFlags {
-    /// The output stream has underflowed.
-    OutputUnderflowed,
-    /// The input stream has overflowed.
-    InputOverflowed
-}
-
 /// Describes stream availability and the number for frames available for reading/writing if there
 /// is any.
 #[derive(Copy, Clone, PartialEq, Debug)]


### PR DESCRIPTION
I've also removed the WriteFlags now as this should solve any under/overrun issues anyway, and we probably should error when an under/overrun occurs on `Stream::write` as it was causing distortions in the audio.

@niclashoyer I'll add this change to SoundStream too