### PR TITLE
Attempted to fix blocking example to work with non-synced duplex streams.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "portaudio"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>",
            "Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "PortAudio bindings for Rust."

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -143,6 +143,7 @@ fn main() {
             let (write_buffer, write_frames) = if buffer_frames >= out_frames {
                 let out_samples = (out_frames * CHANNELS as u32) as usize;
                 let remaining_buffer = buffer[out_samples..].iter().map(|&sample| sample).collect();
+                buffer.truncate(out_samples);
                 let write_buffer = replace(&mut buffer, remaining_buffer);
                 (write_buffer, out_frames)
             }

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -107,6 +107,7 @@ fn main() {
         }
     };
 
+    // We'll use this buffer to transfer samples from the input stream to the output stream.
     let mut buffer = Vec::with_capacity((FRAMES * CHANNELS) as usize);
 
     // Now start the main read/write loop! In this example, we pass the input buffer directly to


### PR DESCRIPTION
Ok, I think this might fix #72 now! @niclashoyer 

I have a feeling it might be because the blocking.rs example wasn't properly handling non-synced duplex streams.

For example, on my device there is always consistently the exact number of frames available for reading and writing as the stream is set up with (256 in the example) and they are always available in consecutive order (which is why passing input buffer directly to the output worked). However in your case it seems get_available just returns what is available at that exact moment and not necessarily in a synchronised order. The changes I made to the blocking.rs example in this PR should address this (hopefully!).

Let me know how it goes!