### PR TITLE
Don't build dylib to avoid run-time linking errors in examples (shown in #85).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/jeremyletang/rust-portaudio.git"
 [lib]
 
 name = "portaudio"
-crate-type = ["dylib", "rlib"]
+crate-type = ["rlib"]
 
 [build-dependencies]
 pkg-config = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "portaudio"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Jeremy Letang <letang.jeremy@gmail.com>",
            "Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "PortAudio bindings for Rust."


### PR DESCRIPTION
I'm unsure if there is a specific reason why we were building the dylib originally - I'm happy to add it back and keep searching for another solution if there is someone who needs it. 