### PR TITLE
Update portaudio::pa::is_format_supported to use optional input/output stream parameters.

### DIFF
--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -72,7 +72,7 @@ fn main() {
     };
 
     // Check that the stream format is supported.
-    if let Err(err) = pa::is_format_supported(&input_stream_params, &output_stream_params, SAMPLE_RATE) {
+    if let Err(err) = pa::is_format_supported(Some(&input_stream_params), Some(&output_stream_params), SAMPLE_RATE) {
         panic!("The given stream format is unsupported: {:?}", err.description());
     }
 

--- a/examples/non_blocking.rs
+++ b/examples/non_blocking.rs
@@ -70,7 +70,7 @@ fn main() {
     };
 
     // Check that the stream format is supported.
-    if let Err(err) = pa::is_format_supported(&input_stream_params, &output_stream_params, SAMPLE_RATE) {
+    if let Err(err) = pa::is_format_supported(Some(&input_stream_params), Some(&output_stream_params), SAMPLE_RATE) {
         panic!("The given stream format is unsupported: {:?}", err.description());
     }
 


### PR DESCRIPTION
This adds support for testing whether a non-duplex format is supported.

Not sure if InvalidDevice is the best error for the None/None case. 
Also -- not sure if you have a column width limit. I saw up to 100 elsewhere. 

